### PR TITLE
yuarel_split_path should return -1 if the given path is NULL

### DIFF
--- a/yuarel.c
+++ b/yuarel.c
@@ -236,6 +236,10 @@ yuarel_split_path(char *path, char **parts, int max_parts)
 {
 	int i = 0;
 
+	if (NULL == path || '\0' == *path) {
+		return -1;
+	}
+
 	do {
 		/* Forward to after slashes */
 		while (*path == '/') path++;


### PR DESCRIPTION
I have made a small improvement:
yuarel_split_path should return -1 if the given path is NULL or an empty string

This makes it more consistent with the other parsing functions.